### PR TITLE
Porting to Qt5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,25 +1,25 @@
-VigraQt4
+VigraQt
 ========
 
 This package contains Qt_ bindings for VIGRA_, in particular for Qt
-version 4.x.  This includes:
+version 4.x (with x>5).  This includes:
 
 - Header files (i.e. ``vigraqimage.hxx``) for letting VIGRA algorithms
-  work directly on Qt images.
+  work directly on Qt images (also applicable for Qt 5.x).
 
 - An image viewer class (QImageViewer) that includes panning and
   zooming, a derived OverlayViewer class that adds overlay support and
-  an OpenGL-based viewer.
+  an OpenGL-based viewer (also applicable for Qt 5.x).
 
 - A color map for displaying images or analysis results in false
   colors, including a Qt widget for interactively editing the color
-  map.
+  map (also applicable for Qt 5.x).
 
 - Python bindings and a designer plugin for including the widgets in
-  your own (C++ or Python-based) applications.
+  your own (C++ or Python-based) applications (for Qt 4.x only).
 
-.. _Qt: http://www.trolltech.com/products/qt/
-.. _VIGRA: http://ukoethe.github.io/vigra/
+.. _Qt: https://www.qt.io/developers/
+.. _VIGRA: https://ukoethe.github.io/vigra/
 
 You can always find the current release at
  https://github.com/hmeine/vigraqt/#vigraqt4

--- a/src/designer-plugin/vigraqtplugins.cxx
+++ b/src/designer-plugin/vigraqtplugins.cxx
@@ -3,7 +3,12 @@
 #include "cmeditor.hxx"
 
 #include <QtDesigner/QDesignerContainerExtension>
-#include <QtDesigner/QDesignerCustomWidgetInterface>
+
+#if QT_VERSION < 0x050000
+	#include <QtDesigner/QDesignerCustomWidgetInterface>
+#else
+	#include <QtUiPlugin/QDesignerCustomWidgetInterface>
+#endif
 
 #include <iostream>
 #include <QtPlugin>
@@ -75,6 +80,9 @@ class VigraQtPlugins
   public QDesignerCustomWidgetCollectionInterface
 {
     Q_OBJECT
+#if QT_VERSION >= 0x050000
+    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QDesignerCustomWidgetCollectionInterface")
+#endif
     Q_INTERFACES(QDesignerCustomWidgetCollectionInterface)
 
 public:
@@ -89,6 +97,7 @@ public:
     }
 };
 
-#include "vigraqtplugins.moc"
-
-Q_EXPORT_PLUGIN(VigraQtPlugins)
+#if QT_VERSION < 0x050000
+	#include "vigraqtplugins.moc"
+	Q_EXPORT_PLUGIN(VigraQtPlugins)
+#endif

--- a/src/designer-plugin/vigraqtplugins.pro
+++ b/src/designer-plugin/vigraqtplugins.pro
@@ -1,5 +1,12 @@
 TEMPLATE     = lib
-CONFIG      += qt warn_on release plugin designer
+CONFIG      += qt warn_on release plugin
+
+greaterThan(QT_MAJOR_VERSION, 4) {
+ 	QT += designer
+} else {
+ 	CONFIG += designer
+}
+
 TARGET       = vigraqtplugins
 
 target.path  = $$[QT_INSTALL_PLUGINS]/designer

--- a/src/vigraqt/cmeditor.cxx
+++ b/src/vigraqt/cmeditor.cxx
@@ -13,6 +13,7 @@
 #include <QPaintEvent>
 #include <QPainter>
 #include <QWidget>
+#include <QMimeData>
 
 using vigra::q2v;
 using vigra::v2qc;

--- a/src/vigraqt/qglimageviewer.cxx
+++ b/src/vigraqt/qglimageviewer.cxx
@@ -165,7 +165,7 @@ void QGLImageWidget::initTexture()
 
         // improve compression by clearing unused pixel data:
         if(compression_)
-            memset(uploadImage.bits(), 0, uploadImage.numBytes());
+            memset(uploadImage.bits(), 0, uploadImage.byteCount());
 
         // copy pixel data
         for(unsigned int y = 0; y < (unsigned)image_.height(); ++y)

--- a/src/vigraqt/qimageviewer.cxx
+++ b/src/vigraqt/qimageviewer.cxx
@@ -699,8 +699,8 @@ void QImageViewer::updateROI(QImage const &roiImage, QPoint const &upperLeft)
 
     // allocate zoomed image
     QImage zoomed(newWidth, newHeight, originalImage_.format());
-    zoomed.setNumColors(originalImage_.numColors());
-    for(int i=0; i<originalImage_.numColors(); ++i)
+    zoomed.setColorCount(originalImage_.colorCount());
+    for(int i=0; i<originalImage_.colorCount(); ++i)
         zoomed.setColor(i, originalImage_.color(i));
 
     // fill zoomed image
@@ -758,8 +758,8 @@ void QImageViewer::createDrawingPixmap()
                   zoom(r.height(), zoomLevel_),
                   originalImage_.format());
 
-    zoomed.setNumColors(originalImage_.numColors());
-    for(int i=0; i<originalImage_.numColors(); ++i)
+    zoomed.setColorCount(originalImage_.colorCount());
+    for(int i=0; i<originalImage_.colorCount(); ++i)
         zoomed.setColor(i, originalImage_.color(i));
 
     zoomImage(r.left(), r.top(), zoomed);

--- a/src/vigraqt/vigraqimage.hxx
+++ b/src/vigraqt/vigraqimage.hxx
@@ -141,8 +141,8 @@ public:
 
         QImage newImage(v2q(newSize), qImage_.format());
 
-        // numColors() returns 0 if the colorTable is not used
-        for(unsigned short c = 0; c < qImage_.numColors(); ++c)
+        // colorCount() returns 0 if the colorTable is not used
+        for(unsigned short c = 0; c < qImage_.colorCount(); ++c)
             newImage.setColor(c, qImage_.color(c));
         qImage_ = newImage;
     }
@@ -271,7 +271,7 @@ public:
 
     void setGrayLevelColors(unsigned short count = 256)
     {
-        qImage_.setNumColors(count);
+        qImage_.setColorCount(count);
         for(unsigned short c = 0; c < count; ++c)
             qImage_.setColor(c, qRgb(c, c, c));
     }


### PR DESCRIPTION
Hi Hans,

I'm currently porting (or trying to port) my projects to Qt5, since Qt4 will somehow become deprecated in future. Since I use your vigraQt-lib in many of my apps for visualizing vigra-images, I did some work here, too. 
So far, I was able to port the library itself and the designer plugins for the widgets to Qt5. By the way, the code still compiles using Qt4.X (X>5). I tested this using Qt4.8 and Qt5.5 under Mac OS X. The Python support would surely require more work - and neither I'm familiar with PyQT(4|5) nor do I have the time to look into this in detail :/.
Maybe you can include this new functionality into your vigraqt project. Or split into vigraqt4 and vigraqt5? And what to do with the python-bindings, where nowadays the vigra images are by-default mapped to python by means of vigranumpy?
